### PR TITLE
Add Custom Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Copy and customize the JSON configuration below to match your setup. Replace pla
         "MCP_SERVER": "https://bearer-auth.mcp-server.ai",
         "BEARER_TOKEN": "your_auth_token"
       }
-    },
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To set up the MCP servers locally, use the following configuration file. Below, 
 
 3. **Bearer Token Authentication**: Supply your authentication token in the `BEARER_TOKEN` field of the `bearer-auth` configuration.
 
+4. **Custom Headers**: Add any custom headers by using the `--header` command line argument in the format `--header "Name: Value"`. Multiple headers can be specified by repeating the `--header` argument.
 Copy and customize the JSON configuration below to match your setup. Replace placeholder values like `your_username`, `your_password`, and `your_auth_token` with your actual credentials.
 
 ```json
@@ -42,7 +43,7 @@ Copy and customize the JSON configuration below to match your setup. Replace pla
         "MCP_SERVER": "https://bearer-auth.mcp-server.ai",
         "BEARER_TOKEN": "your_auth_token"
       }
-    }
+    },
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -4,11 +4,6 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 
-/**
- * Extract custom headers from command line arguments
- * @param {string[]} args - Array of command line arguments
- * @returns {object} Object containing headers
- */
 function extractHeaders(args) {
   const headers = {};
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,32 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 
+/**
+ * Extract custom headers from command line arguments
+ * @param {string[]} args - Array of command line arguments
+ * @returns {object} Object containing headers
+ */
+function extractHeaders(args) {
+  const headers = {};
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--header' && i + 1 < args.length) {
+      const headerValue = args[i + 1];
+      const colonIndex = headerValue.indexOf(':');
+      if (colonIndex > 0) {
+        const headerName = headerValue.substring(0, colonIndex).trim();
+        const headerVal = headerValue.substring(colonIndex + 1).trim();
+        headers[headerName] = headerVal;
+      }
+      i++;
+    }
+  }
+
+  return headers;
+}
+
+const customHeaders = extractHeaders(process.argv.slice(2));
+
 const DEFAULT_LOG_DIR = path.join(process.env.HOME || process.env.USERPROFILE, 'bridge_logs');
 const LOG_FILE = path.join(DEFAULT_LOG_DIR, 'bridge.log');
 
@@ -145,6 +171,10 @@ function processJsonRpcRequest(jsonStr, jsonObj) {
     const basicAuth = Buffer.from(`${process.env.USERNAME}:${process.env.PASSWORD}`).toString('base64');
     headers['Authorization'] = `Basic ${basicAuth}`;
   }
+
+  Object.keys(customHeaders).forEach(headerName => {
+    headers[headerName] = customHeaders[headerName];
+  });
 
   logMessage(`Processing request with ID: ${rpcId}`, null);
 


### PR DESCRIPTION
## Add support for custom HTTP headers via command line arguments

### Changes ⭐️
Adds `--header "Name: Value"` command line argument support to include custom HTTP headers in requests to MCP servers.

### TopHatting 🎩
- [x] Headers are correctly parsed from command line arguments
- [x] Multiple headers work as expected  
- [x] Headers are properly included in HTTP requests
- [x] Existing functionality remains unchanged

### Why 🤔
Some MCP servers require custom headers (API keys, client IDs, etc.) beyond basic authentication. This enables communication with those servers.